### PR TITLE
Add support for ACS 7.2.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,14 +13,15 @@ and optionally:
 
 - [apache\*-share-\*.zip](https://artifacts.alfresco.com/nexus/content/repositories/public/org/alfresco/alfresco-content-services-share-distribution/6.2.2.6/alfresco-content-services-share-distribution-6.2.2.6.zip)
 
-The above links are for Tomcat 9.0.37, ACS 6.2.0-ga, Search Services 1.4.3.4 and Share 6.2.2.6. For Alfresco 7.1, use these with Tomcat 9.0.37:
+The above links are for Tomcat 9.0.37, ACS 6.2.0-ga, Search Services 1.4.3.4 and Share 6.2.2.6. For Alfresco 7.2, use these with Tomcat 9.0.37:
 
-- [alfresco-content-services-community-distribution-7.1.1.zip](https://artifacts.alfresco.com/nexus/content/repositories/public/org/alfresco/alfresco-content-services-community-distribution/7.1.1/alfresco-content-services-community-distribution-7.1.1.zip)
-- [alfresco-search-services-2.0.1.1.zip](https://artifacts.alfresco.com/nexus/content/repositories/public/org/alfresco/alfresco-search-services/2.0.1.1/alfresco-search-services-2.0.1.1.zip)
-- [alfresco-content-services-share-distribution-7.1.1.zip](https://artifacts.alfresco.com/nexus/content/repositories/public/org/alfresco/alfresco-content-services-share-distribution/7.1.1/alfresco-content-services-share-distribution-7.1.1.zip)
+- [alfresco-content-services-community-distribution-7.2.1.zip](https://artifacts.alfresco.com/nexus/content/repositories/public/org/alfresco/alfresco-content-services-community-distribution/7.2.1/alfresco-content-services-community-distribution-7.2.1.zip)
+- [alfresco-search-services-2.0.4.zip](https://artifacts.alfresco.com/nexus/content/repositories/public/org/alfresco/alfresco-search-services/2.0.4/alfresco-search-services-2.0.4.zip)
+- [alfresco-content-services-share-distribution-7.2.1.zip](https://artifacts.alfresco.com/nexus/content/repositories/public/org/alfresco/alfresco-content-services-share-distribution/7.2.1/alfresco-content-services-share-distribution-7.2.1.zip)
 
 Here are links for older versions:
 
+- [alfresco-content-services-community-distribution-7.1.1.zip](https://artifacts.alfresco.com/nexus/content/repositories/public/org/alfresco/alfresco-content-services-community-distribution/7.1.1/alfresco-content-services-community-distribution-7.1.1.zip)
 - [alfresco-content-services-community-distribution-7.0.0.zip](https://artifacts.alfresco.com/nexus/content/repositories/public/org/alfresco/alfresco-content-services-community-distribution/7.0.0/alfresco-content-services-community-distribution-7.0.0.zip)
 - [alfresco-content-services-community-distribution-6.0.7-ga.zip](https://artifacts.alfresco.com/nexus/content/repositories/public/org/alfresco/alfresco-content-services-community-distribution/6.0.7-ga/alfresco-content-services-community-distribution-6.0.7-ga.zip)
 - [alfresco-content-services-community-distribution-6.1.2-ga.zip](https://artifacts.alfresco.com/nexus/content/repositories/public/org/alfresco/alfresco-content-services-community-distribution/6.1.2-ga/alfresco-content-services-community-distribution-6.1.2-ga.zip)

--- a/install-alfresco-6x.sh
+++ b/install-alfresco-6x.sh
@@ -96,8 +96,13 @@ cd ../tomcat/lib
 wget --no-check-certificate https://repo1.maven.org/maven2/mysql/mysql-connector-java/5.1.48/mysql-connector-java-5.1.48.jar
 cd ../..
 
+sMode=none sParam='none"'
+if [[ $ver > "7.1" ]]; then
+  sMode=secret sParam='secret -Dalfresco.secureComms.secret=password"'
+fi
+
 # Disable https from solr to alfresco (NOT FOR PRODUCTION)
-echo 'SOLR_OPTS="$SOLR_OPTS -Dalfresco.secureComms=none"' >> search-services/solr.in.sh
+echo 'SOLR_OPTS="$SOLR_OPTS -Dalfresco.secureComms='$sParam >> search-services/solr.in.sh
 echo JAVA_HOME=\"${JAVA_HOME}\" >> search-services/solr.in.sh
 # First time Solr startup
 search-services/solr/bin/solr start -a "-Dcreate.alfresco.defaults=alfresco,archive"
@@ -127,10 +132,11 @@ share.port=8080
 share.protocol=http
 
 index.subsystem.name=solr6
-solr.secureComms=none
+solr.secureComms=$sMode
 solr.port=8983
 solr.host=localhost
 solr.base.url=/solr
+solr.sharedSecret=password
 
 alfresco-pdf-renderer.exe=bin/alfresco-pdf-renderer
 alfresco.rmi.services.host=0.0.0.0


### PR DESCRIPTION
Replace deprecated solr.secureComms=none with 'secret'